### PR TITLE
Fix issue in routes.py

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -26,7 +26,7 @@ def index():
 @main.route('/register', methods=['GET', 'POST'])
 def register():
     if current_user.is_authenticated:
-        return redirect(url_for('main.homepage'))  # or wherever
+        return redirect(url_for('main.index'))
 
     form = RegistrationForm()
 


### PR DESCRIPTION
When an already‑logged‑in user visits /register, the code executes return redirect(url_for('main.homepage'))
The blueprint has no endpoint called main.homepage, so Flask raises: werkzeug.routing.BuildError: Could not build url for endpoint 'main.homepage'