### PR TITLE
Fix Deletion Crash and Add UTC-Aware Timestamps

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -10,10 +10,9 @@ class User(UserMixin, db.Model):
     username = db.Column(db.String(64), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
-    joined_at = db.Column(db.DateTime, default=datetime.utcnow)
+    joined_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     likes = db.relationship('Like', backref='user', lazy='dynamic')
     favorites = db.relationship('Favorite', backref='user', lazy='dynamic')
-
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
@@ -27,9 +26,12 @@ class GameEntry(db.Model):
     game_title = db.Column(db.String(100))
     date_played = db.Column(db.Date)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    likes = db.relationship('Like', backref='entry', lazy='dynamic')
-    favorites = db.relationship('Favorite', backref='entry', lazy='dynamic')
+    timestamp = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+
+    likes = db.relationship('Like', backref='entry', lazy='dynamic', cascade='all, delete-orphan')
+    favorites = db.relationship('Favorite', backref='entry', lazy='dynamic', cascade='all, delete-orphan')
+    comments = db.relationship('Comment', backref='entry', lazy='dynamic', cascade='all, delete-orphan')
 
     user = db.relationship('User', backref='entries')
 
@@ -37,19 +39,19 @@ class GameEntry(db.Model):
 class Comment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.Text, nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    timestamp = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
 
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     entry_id = db.Column(db.Integer, db.ForeignKey('game_entry.id'), nullable=False)
 
     user = db.relationship('User', backref='comments')
-    entry = db.relationship('GameEntry', backref='comments')
+    
 
 
 class RawCSVEntry(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     raw_data = db.Column(db.Text, nullable=False)
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    timestamp = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
 
 
@@ -57,11 +59,11 @@ class Like(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     entry_id = db.Column(db.Integer, db.ForeignKey('game_entry.id'))
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    timestamp = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
 
 class Favorite(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     entry_id = db.Column(db.Integer, db.ForeignKey('game_entry.id'))
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-
+    timestamp = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))


### PR DESCRIPTION
This pull request introduces two important backend improvements:

Fixed Deletion Crash due to Comments

Added cascade="all, delete-orphan" to the GameEntry.comments relationship to ensure associated comments are automatically removed when a game entry is deleted.

This resolves the IntegrityError caused by orphaned comments referencing deleted entry_id.

Timezone-Aware Timestamps

Replaced deprecated datetime.utcnow() calls with datetime.now(timezone.utc) for all models.

This ensures all timestamps (e.g., joined_at, timestamp for entries, likes, comments, favorites, etc.) are stored in a consistent, UTC-aware format.